### PR TITLE
Split Factory from Device. Removed Gl prefixes.

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -19,7 +19,7 @@ use std::slice;
 use gfx::device as d;
 use gfx::device::draw::{Access, Target};
 use gfx::device::target::*;
-use super::{ArrayBuffer, Buffer, FrameBuffer, Program, Surface, Texture, Sampler, GlResources};
+use super::{ArrayBuffer, Buffer, FrameBuffer, Program, Surface, Texture, Sampler, Resources};
 
 /// Serialized device command.
 #[derive(Copy, Clone, Debug)]
@@ -65,7 +65,7 @@ impl CommandBuffer {
     }
 }
 
-impl d::draw::CommandBuffer<GlResources> for CommandBuffer {
+impl d::draw::CommandBuffer<Resources> for CommandBuffer {
     fn new() -> CommandBuffer {
         CommandBuffer {
             buf: Vec::new(),


### PR DESCRIPTION
A step towards https://github.com/gfx-rs/gfx-rs/issues/668
Based on https://github.com/gfx-rs/gfx-rs/pull/668 but doesn't require it

Warning: wraps gl context into an `Rc`. I don't know another way... do you?

Use API changes:
  1. Factory is now a separate thing
  2. No `Gl` prefixes any more
  3. Use `gfx_device_gl::create()` for initialization